### PR TITLE
Move XboxController to gradle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/main/java/com/frc2879/xboxcontroller"]
-	path = src/main/java/com/frc2879/xboxcontroller
-	url = https://github.com/frc2879/XboxController

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id "jaci.openrio.gradle.GradleRIO" version "2017.1.1"
 }
 
+repositories {
+    maven { url 'https://jitpack.io' }
+}
+
 frc {
     team = "2879"
     robotClass = "com.frc2879.newcomen.Robot"
@@ -22,6 +26,7 @@ wpi {
 dependencies {
     compile wpilib()
     compile talonSrx()
+    compile 'com.github.frc2879:XboxController:1.0'
 }
 
 def robotManifest = {


### PR DESCRIPTION
Start using gradle to get XboxController lib instead of git submodules.